### PR TITLE
Changing to Local file read from External URL

### DIFF
--- a/src/services/IconSources.php
+++ b/src/services/IconSources.php
@@ -29,10 +29,9 @@ class IconSources extends Component
 
     public function getRegisteredIconSources()
     {
-        $icons = Craft::$app->getAssetManager()->getPublishedUrl('@verbb/iconpicker/resources/dist', false, 'json/font-awesome.json');
+        $icons = Craft::$app->getAssetManager()->getPublishedUrl('@verbb/iconpicker/resources/dist', false) . 'json/font-awesome.json';
 
-        $icons = Json::decode(IconPickerHelper::getFileContents($icons));
-
+        $icons = Json::decode(file_get_contents($icons));
         $sources = [
             'font-awesome-all' => [
                 'label' => Craft::t('icon-picker', 'Font Awesome 5 (All)'),


### PR DESCRIPTION
In hosted environments where the IP address may change, and the DNS may not be set internally to allow for external CURLs to be made to the SITE_URL, this change will retrieve the contents of the cached page within the `cpresources` directory where this item is cached.