### PR TITLE
Exclude hidden folder from indexing

### DIFF
--- a/src/iconsets/SvgFolder.php
+++ b/src/iconsets/SvgFolder.php
@@ -82,7 +82,7 @@ class SvgFolder extends IconSet
 
         $files = IconPickerHelper::getFiles($folderPath, [
             'only' => ['*.svg'],
-            'except' => ['*-sprites.svg'],
+            'except' => ['*-sprites.svg', '_*'],
             'recursive' => true,
         ]);
 


### PR DESCRIPTION
Remove hidden (transform) folder from indexing for svg files